### PR TITLE
Standardize indentation for multi-level lists.

### DIFF
--- a/wca-motions/1-Spirit.md
+++ b/wca-motions/1-Spirit.md
@@ -9,6 +9,9 @@
 # Motion
 
 1. The World Cube Association (WCA) is the world governing body for the sport of Speedcubing.
+
 2. The Mission of the World Cube Association is to have more competitions in more countries with more people and more fun, under fair and equal conditions.
+
 3. The Spirit of the World Cube Association is that people from all over the world have fun together in a friendly atmosphere, help each other, and behave in a sportsmanlike fashion.
+
 4. The World Cube Association exists for its Registered Speedcubers and thus the key value of WCA Staff and External Staff is to serve the Registered Speedcubers of the WCA, see [WCA Motion : Registered Speedcubers](../7/Registered-Speedcubers.md).

--- a/wca-motions/3-Objectives.md
+++ b/wca-motions/3-Objectives.md
@@ -10,25 +10,28 @@
 
 The Objectives of the WCA are:
 
-1. Organize  
-1.1. To act as the world governing body for the sport of Speedcubing.  
-1.2. To encourage and sustain participation in Speedcubing throughout the world, regardless of age, gender, race, religious views, political views, physical abilities, or any other factor.  
-1.3. To foster and support the worldwide development of Speedcubing and the spreading of technical, medical, logistical, statistical, financial, or other information that achieves this aim to its Registered Speedcubers.  
-1.4. To register, publish, and preserve all the results from WCA Competitions.  
-1.5. To recognize and publish World, Continental, and National records and rankings in Speedcubing.
-2. Build and sustain an inclusive community  
-2.1. To promote friendship and fun around WCA Competitions and in the WCA Community.  
-2.2. To strive to ensure that no discrimination in age, gender, race, religious views, political views, or physical abilities exists, continues to exist, or is allowed to develop in the WCA Community in any form.  
-2.3. To promote the sport of Speedcubing and its values as an educational subject, and a life affirming and life enhancing activity.  
-2.4. To promote fair play around WCA Competitions and in the WCA Community.  
-2.5. To encourage and support a responsible concern for environmental issues and to promote sustainable development in Speedcubing.  
-2.6. To be accountable for all actions on behalf of the WCA to the WCA Community.
-3. Regulate  
-3.1. To compile and enforce regulations governing Speedcubing and to ensure that such regulations are applied at all WCA Competitions.  
-3.2. To create and enforce a mechanism whereby disputes and disciplinary matters within Speedcubing are subject to procedures set out in the applicable regulations and to bring all disputes to final resolution by arbitration.  
-3.3. To supervise and enforce the rights and duties of Staff, External Staff, Registered Speedcubers, and Partners.  
-3.4. To safeguard the authenticity and integrity of the WCA and to take all possible measures to eliminate corrupt conduct that might place the authenticity or integrity of the WCA at risk.  
-3.5. To enforce publicly transparent processes within the WCA in order to support the accountability towards the WCA Community.  
-3.6. To enforce transparent processes within the WCA in order to comply with local laws and to cooperate with local law enforcement in case of alleged violations of the local laws.  
-4. Cooperate to further develop and sustain the WCA  
-4.1. To foster and develop links with other International Federations, National Governments, Inter-Governmental Organizations, and International and National Non-Governmental Organizations in order to promote the interests of Speedcubing, at all levels throughout the world.
+1. Organize
+   - 1.1. To act as the world governing body for the sport of Speedcubing.
+   - 1.2. To encourage and sustain participation in Speedcubing throughout the world, regardless of age, gender, race, religious views, political views, physical abilities, or any other factor.
+   - 1.3. To foster and support the worldwide development of Speedcubing and the spreading of technical, medical, logistical, statistical, financial, or other information that achieves this aim to its Registered Speedcubers.
+   - 1.4. To register, publish, and preserve all the results from WCA Competitions.
+   - 1.5. To recognize and publish World, Continental, and National records and rankings in Speedcubing.
+
+2. Build and sustain an inclusive community
+   - 2.1. To promote friendship and fun around WCA Competitions and in the WCA Community.
+   - 2.2. To strive to ensure that no discrimination in age, gender, race, religious views, political views, or physical abilities exists, continues to exist, or is allowed to develop in the WCA Community in any form.
+   - 2.3. To promote the sport of Speedcubing and its values as an educational subject, and a life affirming and life enhancing activity.
+   - 2.4. To promote fair play around WCA Competitions and in the WCA Community.
+   - 2.5. To encourage and support a responsible concern for environmental issues and to promote sustainable development in Speedcubing.
+   - 2.6. To be accountable for all actions on behalf of the WCA to the WCA Community.
+
+3. Regulate
+   - 3.1. To compile and enforce regulations governing Speedcubing and to ensure that such regulations are applied at all WCA Competitions.
+   - 3.2. To create and enforce a mechanism whereby disputes and disciplinary matters within Speedcubing are subject to procedures set out in the applicable regulations and to bring all disputes to final resolution by arbitration.
+   - 3.3. To supervise and enforce the rights and duties of Staff, External Staff, Registered Speedcubers, and Partners.
+   - 3.4. To safeguard the authenticity and integrity of the WCA and to take all possible measures to eliminate corrupt conduct that might place the authenticity or integrity of the WCA at risk.
+   - 3.5. To enforce publicly transparent processes within the WCA in order to support the accountability towards the WCA Community.
+   - 3.6. To enforce transparent processes within the WCA in order to comply with local laws and to cooperate with local law enforcement in case of alleged violations of the local laws.
+
+4. Cooperate to further develop and sustain the WCA
+   - 4.1. To foster and develop links with other International Federations, National Governments, Inter-Governmental Organizations, and International and National Non-Governmental Organizations in order to promote the interests of Speedcubing, at all levels throughout the world.


### PR DESCRIPTION
Is it possible to get rid of the preceding `·` for nested lists?